### PR TITLE
feat(normalize): Add optional NaN handling with `fillna_zero` parameter

### DIFF
--- a/anomalylab/core/core.py
+++ b/anomalylab/core/core.py
@@ -137,6 +137,7 @@ class Panel:
         group_columns: Columns = None,
         no_process_columns: Columns = None,
         process_all_characteristics: bool = True,
+        fillna_zero: bool = False,
     ) -> Panel:
         """
         Normalizes specified columns of the DataFrame using the chosen method.
@@ -157,6 +158,8 @@ class Panel:
                 normalization. Defaults to None.
             process_all_characteristics (bool, optional): Whether to process all
                 characteristics or not. Defaults to True.
+            fillna_zero (bool): If True, fills NaN values with zero after normalization.
+                Defaults to False.
 
         Returns:
             Normalize: The instance of the Normalize class with updated state.
@@ -171,6 +174,7 @@ class Panel:
             group_columns=group_columns,
             no_process_columns=no_process_columns,
             process_all_characteristics=process_all_characteristics,
+            fillna_zero=fillna_zero,
         ).panel_data
         return self
 

--- a/anomalylab/empirical/portfolio.py
+++ b/anomalylab/empirical/portfolio.py
@@ -142,7 +142,7 @@ class PortfolioAnalysis(Empirical):
                         )
                     )
                     .reset_index()
-                    .set_index(f"level_{1}")
+                    .set_index(f"level_1")
                     .drop(self.time, axis=1)
                 )
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="AnomalyLab",
-    version="0.4.2",
+    version="0.4.3",
     author="FinPhd",
     author_email="chenhaiwei@stu.sufe.edu.cn",
     description="A Python package for empirical asset pricing analysis.",


### PR DESCRIPTION
- Introduce a new boolean parameter `fillna_zero` (default=False) to toggle zero replacement for NaN values after normalization
- Original implementation always filled NaNs with 0, which is now an opt-in behavior by setting `fillna_zero=True`
- BREAKING CHANGE: Existing calls without `fillna_zero` will return DataFrames with potential NaNs.